### PR TITLE
fix: ability to re-run action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ runs:
     - id: setup-certificates
       shell: bash
       run: |
-        mkdir ~/certs
+        mkdir -p ~/certs
         echo "${{ inputs.maven-p12 }}" | base64 -d > ${HOME}/certs/certificate.p12
         echo "${{ inputs.mtls-cacert }}" | base64 -d > ${HOME}/certs/rootca.crt
         echo "export MAVEN_OPTS=\"-Djavax.net.ssl.keyStore=${HOME}/certs/certificate.p12 -Djavax.net.ssl.keyStoreType=pkcs12 -Djavax.net.ssl.keyStorePassword=${{ inputs.maven-p12-password }}\"" \


### PR DESCRIPTION
Use case: Some legacy systems need to compile on java 8 but run sonar on java 11, so we need to be able to configure multiple JVM's in the same job.

This change should make the changed idempotent, basically not failing when creating the certs folder if its already there.